### PR TITLE
Add build tips to readme, expand gitignore for all configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
-/cmake-build-debug/
+/cmake-build-*/
 /files/
 /.idea/

--- a/README.md
+++ b/README.md
@@ -2,9 +2,6 @@
 
 For tree search and simulation of the popular rogue-like deckbuilder game Slay The Spire
 
-requires https://github.com/nlohmann/json
-(download the zip and place the folder in the main project folder)
-
 **Features**
 * c++ 17 compiled with gcc
 * Standalone
@@ -25,7 +22,11 @@ requires https://github.com/nlohmann/json
 * Everything outside of combat / all acts
 
 **Getting Started**
-* The project was built with Clion2021 and the mingw64 toolchain on Windows 10
+* The project was built with Clion2021 and the [mingw64 toolchain](https://www.msys2.org/) on Windows 10
 * The main target creates a simulator of the game that can be played in console.
 * The test target creates a program with various commands that can be run, including random simulation
 * Click the star button at the top of the repo :)
+
+**Build tips**
+* If your build fails with an error about not-return-only `constexpr` methods, ensure your compiler supports c++17.
+* If CLion shows an error about not finding python libs when loading the cmake project, try opening CLion from the msys2 shell.


### PR DESCRIPTION
Removed the bit about downloading the json manually because I think submodules are handled automatically. At least, that was my experience. Happy to add it back if you want.

Other bits are hiccups I hit as a VS-acclimated dev learning CLion.