### PR TITLE
fix(combat): Iron Wave applies calculateCardBlock twice

### DIFF
--- a/src/combat/BattleContext.cpp
+++ b/src/combat/BattleContext.cpp
@@ -1073,7 +1073,7 @@ void BattleContext::useAttackCard() {
         }
 
         case CardId::IRON_WAVE: {
-            addToBot( Actions::GainBlock(calculateCardBlock(calculateCardBlock(up  ? 7 : 5))) );
+            addToBot( Actions::GainBlock(calculateCardBlock(up  ? 7 : 5)) );
             addToBot( Actions::AttackEnemy(t, calculateCardDamage(c, t, up ? 7 : 5)) );
             break;
         }


### PR DESCRIPTION
`IRON_WAVE` wraps its block value in a nested `calculateCardBlock(calculateCardBlock(...))` call, so Dexterity is counted twice (and Frail's `* 3 / 4` would be applied twice as well).

```cpp
// BattleContext.cpp, useAttackCard()
case CardId::IRON_WAVE: {
    addToBot( Actions::GainBlock(calculateCardBlock(calculateCardBlock(up  ? 7 : 5))) );
    addToBot( Actions::AttackEnemy(t, calculateCardDamage(c, t, up ? 7 : 5)) );
    break;
}
```

### Why this looks like a typo rather than intent

- Every other block card applies it once — I count 15 single-application sites and this one nested site.
- No test covers this card.
- Observed behaviour: with Dexterity 2, Iron Wave grants **9** block (`5 + 2 + 2`). In the game it grants **7** (`5 + 2`).

### Change

Apply `calculateCardBlock` once, matching the other block cards.

### How I ran into it

I'm porting the combat engine to TypeScript and using this project as the oracle — driving the real `BattleContext` and diffing my implementation against it frame by frame. This showed up as a block mismatch on traces where the player had Dexterity.

Thanks for this project — having an exact reimplementation to diff against has been enormously useful.